### PR TITLE
Added a upcoming trips action method 

### DIFF
--- a/passportapi/models/trip.py
+++ b/passportapi/models/trip.py
@@ -10,3 +10,6 @@ class Trip(models.Model):
     return_date = models.DateField(auto_now=False, auto_now_add=False)
     reasons = models.ManyToManyField("Reason", through="TripReason")
     user = models.ForeignKey(User, on_delete=models.CASCADE, related_name='planned_trips')
+
+    class Meta:
+        ordering = ( '-departure_date', )

--- a/passportapi/views/trip_view.py
+++ b/passportapi/views/trip_view.py
@@ -6,6 +6,7 @@ from rest_framework import serializers, status
 from rest_framework.decorators import action
 from django.contrib.auth.models import User
 from passportapi.models import Trip, Reason, TripReason
+from datetime import date
 
 
 class TripView(ViewSet):
@@ -108,7 +109,7 @@ class TripView(ViewSet):
     @action(methods=['get'], detail=False)
     def reasons(self, request):
         """
-        @api {GET} /trips/reasons GET avialable trip reasons
+        @api {GET} /trips/reasons GET available trip reasons
         """
 
         if request.method == 'GET':
@@ -117,6 +118,17 @@ class TripView(ViewSet):
             serializer = ReasonSerializer(
                 reasons, many=True, context={'request': request})
             return Response(serializer.data)
+        
+    @action(methods=['get'], detail=False)
+    def upcoming(self, request):
+        """Determines the number of upcoming trips for the user
+        @api {GET} /trips/upcoming GET upcoming trip count
+        """
+        user=request.auth.user
+        upcoming_trips = Trip.objects.filter(
+            user=user, departure_date__gt=date.today())
+        return Response(upcoming_trips.count(), status=status.HTTP_200_OK)
+    
         
 class ReasonSerializer(serializers.ModelSerializer):
     class Meta:


### PR DESCRIPTION
## Description 

The client needs to display the number of upcoming trips for the user.  Instead of filtering all of the users trips on the client side, the server will filter out any trips that have passed and count number of upcoming trips for the client.  An upcoming custom action was added to perform this logic.  The client also wants to display the trips in descending order based on departure_date. 

## Changes

- Added a upcoming custom method to the trip view 
- Added an ordering meta class to the trip model to display trips in descending order by default


## Requests / Responses

**Request**

GET `/trips/upcoming` GETs the upcoming trip count

**Response**

HTTP/1.1 201 OK

```
{ 
     2 
}
```

## Steps to test 
```
git fetch origin vs-trip-count
get checkout vs-trip-count
```
- Pull down branch from passport-client repo pull request # 28
- Navigate to the trips page
- Verify that the trip count is displaying in a header 
- Add a trip with a future departure date 
- Verify that the trip count updated to account for the additional trip 