### PR TITLE
Added a GET request handler to the /stamps/photos view

### DIFF
--- a/passportapi/models/stamp_journal.py
+++ b/passportapi/models/stamp_journal.py
@@ -8,4 +8,6 @@ class StampJournal(models.Model):
     type = models.ForeignKey("Type", on_delete=models.DO_NOTHING, related_name='stamp_journal_type')
     date_created = models.DateTimeField(auto_now_add=True)
     public = models.BooleanField(default=False)
-    
+
+    class Meta:
+        ordering = ( '-date_created', )

--- a/passportapi/models/stamp_photo.py
+++ b/passportapi/models/stamp_photo.py
@@ -1,5 +1,6 @@
 from django.db import models
 
+
 class StampPhoto(models.Model):
     image = models.ImageField(upload_to='photos', height_field=None,
         width_field=None, max_length=None, null=True, blank=True)
@@ -9,4 +10,7 @@ class StampPhoto(models.Model):
     type = models.ForeignKey("Type", on_delete=models.DO_NOTHING, related_name='stamp_photo_type')
     date_created = models.DateTimeField(auto_now_add=True)
     public = models.BooleanField(default=False)
+
+    class Meta:
+        ordering = ( '-date_created', )
     

--- a/passportapi/models/stamp_product.py
+++ b/passportapi/models/stamp_product.py
@@ -9,4 +9,6 @@ class StampProduct(models.Model):
     type = models.ForeignKey("Type", on_delete=models.DO_NOTHING, related_name='stamp_product_type')
     date_created = models.DateTimeField(auto_now_add=True)
     public = models.BooleanField(default=False)
-    
+
+    class Meta:
+        ordering = ( '-date_created', )

--- a/passportapi/views/auth.py
+++ b/passportapi/views/auth.py
@@ -27,7 +27,6 @@ def login_user(request):
         data = {
             'valid': True,
             'token': token.key,
-            'id': authenticated_user.id,
             'first_name': authenticated_user.first_name,
         }
         return Response(data)
@@ -64,8 +63,7 @@ def register_user(request):
         token = Token.objects.create(user=new_user)
         # Return the token to the client
         # This is where we update what gets sent back to the client for localStorage
-        data = { 
-            'id': new_user.id,
+        data = {
             'first_name': new_user.first_name,
             'token': token.key 
         }

--- a/passportapi/views/stamp_view.py
+++ b/passportapi/views/stamp_view.py
@@ -22,7 +22,7 @@ class StampView(ViewSet):
         serializer = TypeSerializer(types, many=True)
         return Response(serializer.data)
     
-    @action(methods=['post'], detail=False)
+    @action(methods=['post', 'get'], detail=False)
     def photos(self, request):
         """Post a new stamp photo
         @api {POST} /stamps/photos POST stamp photo
@@ -54,6 +54,19 @@ class StampView(ViewSet):
             serializer = PhotoSerializer(
                 stamp_photo, many=False, context={'request': request})
             return Response(serializer.data, status=status.HTTP_201_CREATED)
+        elif request.method == "GET":
+            """Gets all stamp photos
+            @api {GET} /stamps/photos GET stamp photos
+            """
+
+            photos = StampPhoto.objects.all()
+            
+            filtering = request.query_params.get("filter_by", None)
+            if filtering is not None and filtering == "user":
+                photos = photos.filter(trip__user=request.auth.user)
+            
+            serializer = PhotoSerializer(photos, many=True)
+            return Response(serializer.data)
         
         return Response(None, status=status.HTTP_405_METHOD_NOT_ALLOWED)
         

--- a/passportapi/views/trip_view.py
+++ b/passportapi/views/trip_view.py
@@ -33,8 +33,9 @@ class TripView(ViewSet):
         """
         trips = Trip.objects.all()
 
-        if "user_id" in request.query_params:
-            trips = trips.filter(user=request.query_params['user_id'])
+        filtering = request.query_params.get("filter_by", None)
+        if filtering is not None and filtering == "user":
+            trips = trips.filter(user=request.auth.user)
 
         serializer = TripSerializer(trips, many=True)
         return Response(serializer.data)


### PR DESCRIPTION
## Description

1) The client needs to display all stamp photos.  The get request handler was added to handle these requests.  
2) Additional user info shouldn't be provided in the local storage item.  Removed this info since it should be accessed through the user's token. 

## Changes

- Added a get handler to the /stamps/photos action decorator to handle get requests
- Updated the journal, product, and photo models to default order by date_created descending
- Removed the user.id from the auth data sent back to the client
- Updated the trip view to use the token auth for user instead of passing the user in the auth data

## Testing
```
git fetch origin vs-stamps-list
get checkout vs-stamps-list
- Pull down the changes from passport-client, pull request # 
- Add a new stamp photo from the stamps page 
- Verify the photo displays on the stamps page after creation 
- Check the local storage item in the Applications tab of the developer tools.  Verify only the token is provided with no other user information. 